### PR TITLE
Pop usmerge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 # Other files here:
 output.log
 
+# Debian Packaging artefacts:
+debian/.debhelper/
+debian/kernelstub
+debian/*.debhelper
+debian/*.substvars
+debian/files
+
 # Editor TMP files
 *~
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Usage is fairly straightforward and usually only requires running the command as
 root with `su`/`sudo`. If your computer requires special kernel parameters to
 boot, you can specify them as such:
 ```
-sudo kernelstub -c "options_go here wrapped in-quotes"
+sudo kernelstub -o "options_go here wrapped in-quotes"
 ```
 Running the command with `-o` will save the options used into the user section
 of the configuration file (see _Configuration_ below) so that you don't need to

--- a/bin/kernelstub
+++ b/bin/kernelstub
@@ -49,106 +49,116 @@ def main(options=None): # Do the thing
     parser = argparse.ArgumentParser(
         description = "Automatic Kernel EFIstub manager")
     loader_stub = parser.add_mutually_exclusive_group()
+    install_loader = parser.add_mutually_exclusive_group()
 
     parser.add_argument(
         '-d',
         '--dry-run',
         action = 'store_true',
         dest = 'dry_run',
-        help = 'Don\'t perform any actions, just simulate them.'
-    )
+        help = 'Don\'t perform any actions, just simulate them.')
+    parser.add_argument(
+        '-p',
+        '--print-config',
+        action = 'store_true',
+        dest = 'print_config',
+        help = 'Print the current configuration and exit')
 
     parser.add_argument(
         '-e',
         dest = 'esp_path',
         metavar = 'ESP,',
-        help = ''
-    )
+        help = '')
     parser.add_argument(
         '--esp-path',
         dest = 'esp_path',
         metavar = 'ESP',
-        help = 'Manually specify the path to the ESP. Default is /boot/efi'
-    )
+        help = 'Manually specify the path to the ESP. Default is /boot/efi')
+
+    parser.add_argument(
+        '-r',
+        dest = 'root_path',
+        metavar = 'ROOT',
+        help = '')
+    parser.add_argument(
+        '--root-path',
+        dest = 'root_path',
+        metavar = 'ROOT',
+        help = 'The path where the root filesystem to use is mounted.')
 
     parser.add_argument(
         '-k',
         dest = 'kernel_path',
         metavar= 'PATH,',
-        help = ''
-    )
+        help = '')
     parser.add_argument(
         '--kernel-path',
         dest = 'kernel_path',
         metavar= 'PATH',
-        help = 'The path to the kernel image.'
-    )
+        help = 'The path to the kernel image.')
 
     parser.add_argument(
         '-i',
         dest = 'initrd_path',
         metavar = 'PATH,',
-        help = ''
-    )
+        help = '')
     parser.add_argument(
         '--initrd-path',
         dest = 'initrd_path',
         metavar = 'PATH',
-        help = 'The path to the initrd image.'
-    )
+        help = 'The path to the initrd image.')
 
     parser.add_argument(
         '-o',
         dest = 'k_options',
         metavar = '"OPTIONS",',
-        help = ''
-    )
+        help = '')
     parser.add_argument(
         '--options',
         dest = 'k_options',
         metavar = '"OPTIONS"',
-        help = 'The boot options to be passed to the kernel'
-    )
+        help = 'The boot options to be passed to the kernel')
 
-    parser.add_argument(
+    install_loader.add_argument(
         '-l',
         '--loader',
         action = 'store_true',
         dest = 'setup_loader',
-        help = 'Creates a systemd-boot compatible loader configuration'
-    )
+        help = 'Creates a systemd-boot compatible loader configuration')
+    install_loader.add_argument(
+        '-n',
+        '--no-loader',
+        action = 'store_true',
+        dest = 'off_loader',
+        help = 'Turns off creating loader configuration')
 
     loader_stub.add_argument(
         '-s',
         '--stub',
         action = 'store_true',
         dest = 'install_stub',
-        help = 'Set up NVRAM entries for the copied kernel'
-    )
+        help = 'Set up NVRAM entries for the copied kernel')
 
     loader_stub.add_argument(
         '-m',
         '--manage-only',
         action = 'store_true',
         dest = 'manage_mode',
-        help = 'Only copy entries, don\'t set up the NVRAM'
-    )
+        help = 'Only copy entries, don\'t set up the NVRAM')
 
     parser.add_argument(
         '-f',
         '--force-update',
         action = 'store_true',
         dest = 'force_update',
-        help = 'Forcibly update any loader.conf to set the new entry as the default'
-    )
+        help = 'Forcibly update any loader.conf to set the new entry as the default')
 
     parser.add_argument(
         '-v',
         '--verbose',
         action = 'count',
         dest = 'verbosity',
-        help = 'Increase program verbosity and display extra output.'
-    )
+        help = 'Increase program verbosity and display extra output.')
 
     args = parser.parse_args()
     if options:

--- a/data/initramfs/zz-kernelstub
+++ b/data/initramfs/zz-kernelstub
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 KERNEL="/boot/vmlinuz-$1"
+INITRD="$2"
 
-kernelstub --verbose --initrd-path "$2" --kernel-path "$KERNEL"
+kernelstub --verbose --initrd-path "/initrd.img" --kernel-path "/vmlinuz"

--- a/data/kernel/zz-kernelstub
+++ b/data/kernel/zz-kernelstub
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 INITRD="/boot/initrd.img-$1"
+KERNEL="$2"
 
-kernelstub --verbose --kernel-path "$2" --initrd-path "$INITRD"
+kernelstub --verbose --initrd-path "/initrd.img" --kernel-path "/vmlinuz"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+kernelstub (2.0.5) artful; urgency=medium
+
+  * Add options for:
+    - Specifying Root filesystem path (for recovery)
+    - Printing current configuration options
+    - Turning off setting up the loader config
+  * Update automatic hooks to use / symlinks
+
+ -- Ian Santopietro <ian@system76.com>  Mon, 05 Feb 2018 10:36:13 -0700
+
 kernelstub (2.0.4) artful; urgency=medium
 
   * Use /vmlinuz and /initrd.img symlinks

--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,0 +1,1 @@
+/etc/default/kernelstub.SAMPLE

--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,2 +1,1 @@
 /etc/default/kernelstub.SAMPLE
-/etc/default/kernelstub

--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,1 +1,2 @@
 /etc/default/kernelstub.SAMPLE
+/etc/default/kernelstub

--- a/debian/pop-boot.install
+++ b/debian/pop-boot.install
@@ -1,1 +1,0 @@
-data/config/kernelstub /etc/default/

--- a/debian/pop-boot.postinst
+++ b/debian/pop-boot.postinst
@@ -7,7 +7,6 @@ kernelstub \
 	--options "quiet loglevel=0" \
 	--loader \
 	--manage-only \
-	--force \
 	--verbose
 
-bootctl install
+bootctl install --path=/boot/efi

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -62,6 +62,9 @@ class Kernelstub():
         if verbosity > 2:
             verbosity = 2
 
+        if args.print_config:
+            verbosity = 1
+
         level = {
             0 : 'WARNING',
             1 : 'INFO',
@@ -89,6 +92,10 @@ class Kernelstub():
         if args.esp_path:
             configuration['esp_path'] = args.esp_path
 
+        root_path = "/"
+        if args.root_path:
+            root_path = args.root_path
+
         opsys = Opsys.OS()
 
         if args.kernel_path:
@@ -96,12 +103,16 @@ class Kernelstub():
                 'Manually specified kernel path:\n ' +
                 '               %s' % args.kernel_path)
             opsys.kernel_path = args.kernel_path
+        else:
+            opsys.kernel_path = os.path.join(root_path, opsys.kernel_name)
 
         if args.initrd_path:
             log.debug(
                 'Manually specified initrd path:\n ' +
                 '               %s' % args.initrd_path)
             opsys.initrd_path = args.initrd_path
+        else:
+            opsys.initrd_path = os.path.join(root_path, opsys.initrd_name)
 
         if not os.path.exists(opsys.kernel_path):
             log.critical('Can\'t find the kernel image! \n\n'
@@ -134,11 +145,12 @@ class Kernelstub():
         log.debug(config.print_config())
 
         if args.setup_loader:
-            configuration['setup_loader'] = args.setup_loader
+            configuration['setup_loader'] = True
+        if args.off_loader:
+            configuration['setup_loader'] = False
 
         if args.install_stub:
             configuration['manage_mode'] = False
-
         if args.manage_mode:
             configuration['manage_mode'] = True
 
@@ -167,14 +179,13 @@ class Kernelstub():
             log.debug('Configuration we got: \n\n%s' % config.print_config())
             exit(4)
 
-        drive = Drive.Drive(esp_path=esp_path)
+        drive = Drive.Drive(root_path=root_path, esp_path=esp_path)
         nvram = Nvram.NVRAM(opsys.name, opsys.version)
         installer = Installer.Installer(nvram, opsys, drive)
 
         # Log some helpful information, to file and optionally console
         info = (
             '    OS:..................%s %s\n'   %(opsys.name_pretty,opsys.version) +
-            '    Drive name:........../dev/%s\n' % drive.name +
             '    Root partition:....../dev/%s\n' % drive.root_fs +
             '    Root FS UUID:........%s\n'      % drive.root_uuid +
             '    ESP Path:............%s\n'      % esp_path +
@@ -187,6 +198,16 @@ class Kernelstub():
             '    Initrd Image Path:...%s\n'      % opsys.initrd_path)
 
         log.info('System information: \n\n%s' % info)
+
+        if args.print_config:
+            all_config = (
+                '   Kernel options:................%s\n' % configuration['kernel_options'] +
+                '   ESP Location:..................%s\n' % configuration['esp_path'] +
+                '   Management Mode:...............%s\n' % configuration['manage_mode'] +
+                '   Install Loader configuration:..%s\n' % configuration['setup_loader'])
+            log.info('Configuration details: \n\n%s' % all_config)
+            exit(0)
+
         log.debug('Setting up boot...')
 
         kopts = 'root=UUID=%s ro %s' % (drive.root_uuid, kernel_opts)

--- a/kernelstub/drive.py
+++ b/kernelstub/drive.py
@@ -26,6 +26,7 @@ import os, subprocess, logging
 
 class Drive():
 
+    name = 'none'
     root_fs = '/'
     root_uuid = '12345-12345-12345'
     esp_fs = '/boot/efi'
@@ -43,6 +44,9 @@ class Drive():
         self.drive_dict = self.parse_proc_partitions()
         self.log.debug('drive_dict = %s' % self.drive_dict)
 
+        self.name = self.get_drive_name(root_path)
+        self.log.debug('drive name: /dev/%s' % self.name)
+
         self.log.debug('root_path = %s' % root_path)
         self.root_fs = self.get_part_name(root_path)
         self.log.debug('root_fs = %s ' % self.root_fs)
@@ -56,6 +60,11 @@ class Drive():
         major = self.get_maj(path)
         minor = self.get_min(path)
         name = self.drive_dict[(major, minor)]
+        return name
+
+    def get_drive_name(self, path):
+        major = self.get_maj(path)
+        name = self.drive_dict[(major, 0)]
         return name
 
     def parse_proc_partitions(self):

--- a/kernelstub/drive.py
+++ b/kernelstub/drive.py
@@ -22,62 +22,69 @@ Please see the provided LICENSE.txt file for additional distribution/copyright
 terms.
 """
 
-import os, subprocess
+import os, subprocess, logging
 
 class Drive():
 
-    name = "none"
-    root_fs = "/"
-    root_uuid = "12345-12345-12345"
-    esp_fs = "/boot/efi"
-    esp_path = "/boot/efi"
+    root_fs = '/'
+    root_uuid = '12345-12345-12345'
+    esp_fs = '/boot/efi'
+    esp_path = '/boot/efi'
     esp_num = 0
 
     def __init__(self, root_path="/", esp_path="/boot/efi"):
+        self.log = logging.getLogger('kernelstub.Drive')
+        self.log.debug('Logging set up')
+        self.log.debug('loaded kernelstub.Drive')
+
         self.esp_path = esp_path
-        self.drive_name = self.get_drive_name(root_path)
+        self.log.debug('esp_path = %s' % self.esp_path)
+
+        self.drive_dict = self.parse_proc_partitions()
+        self.log.debug('drive_dict = %s' % self.drive_dict)
+
+        self.log.debug('root_path = %s' % root_path)
         self.root_fs = self.get_part_name(root_path)
+        self.log.debug('root_fs = %s ' % self.root_fs)
+
         self.root_uuid = self.get_uuid(self.root_fs)
         self.esp_fs = self.get_part_name(esp_path)
         self.esp_num = self.esp_fs[-1]
 
-    def get_drive_name(self, path):
-        major = self.get_maj(path)
-        dInfo = self.parse_proc_partitions()
-        name = dInfo[(major, 0)]
-        return name
 
     def get_part_name(self, path):
         major = self.get_maj(path)
         minor = self.get_min(path)
-        pInfo = self.parse_proc_partitions()
-        name = pInfo[(major, minor)]
+        name = self.drive_dict[(major, minor)]
         return name
 
     def parse_proc_partitions(self):
         res = {}
-        f = open("/proc/partitions", "r")
-        for line in f:
-            fields = line.split()
-            try:
-                tmaj = int(fields[0])
-                tmin = int(fields[1])
-                name = fields[3]
-                res[(tmaj, tmin)] = name
-            except:
-                # just ignore parse errors in header/separator lines
-                pass
-        f.close()
+        with open('/proc/partitions', mode='r') as parts:
+            for line in parts:
+                fields = line.split()
+                try:
+                    tmaj = int(fields[0])
+                    tmin = int(fields[1])
+                    name = fields[3]
+                    res[(tmaj, tmin)] = name
+                except:
+                    # just ignore parse errors in header/separator lines
+                    pass
         return res
 
     def get_maj(self, path):
         dev = os.stat(path).st_dev
         major = os.major(dev)
+
+        self.log.debug('Major for %s = %s' % (path, major))
         return major
 
     def get_min(self, path):
         dev = os.stat(path).st_dev
         minor = os.minor(dev)
+
+        self.log.debug('Minor for %s = %s' % (path, minor))
         return minor
 
     def get_uuid(self, fs):

--- a/kernelstub/nvram.py
+++ b/kernelstub/nvram.py
@@ -59,12 +59,12 @@ class NVRAM():
 
 
     def add_entry(self, this_os, this_drive, kernel_opts):
-        device = '/dev/%s' % this_drive.drive_name
+        device = '/dev/%s' % this_drive.name
         esp_num = this_drive.esp_num
-        entry_label = '%s %s' % (this_os.os_name, this_os.os_version)
-        entry_linux = '\\EFI\\%s\\vmlinuz' % this_os.os_name
+        entry_label = '%s %s' % (this_os.name_pretty, this_os.version)
+        entry_linux = '\\EFI\\%s-%s\\vmlinuz' % (this_os.name, this_drive.root_uuid)
         root_uuid = this_drive.root_uuid
-        entry_initrd = 'EFI/%s/initrd' % this_os.os_name
+        entry_initrd = 'EFI/%s-%s/initrd' % (this_os.name, this_drive.root_uuid)
         kernel_opts = kernel_opts
         command = [
             '/usr/bin/sudo',
@@ -75,9 +75,8 @@ class NVRAM():
             '-L', '"%s"' % entry_label,
             '-l', entry_linux,
             '-u',
-            '"root=UUID=%s' % root_uuid,
-            'initrd=%s' % entry_initrd,
-            'ro'
+            '"initrd=%s' % entry_initrd,
+            '%s"' % kernel_opts,
         ]
         for option in kernel_opts:
             command.append(option)

--- a/kernelstub/nvram.py
+++ b/kernelstub/nvram.py
@@ -22,7 +22,7 @@ Please see the provided LICENSE.txt file for additional distribution/copyright
 terms.
 """
 
-import subprocess
+import subprocess, logging
 
 class NVRAM():
 
@@ -32,6 +32,10 @@ class NVRAM():
     order_num = "0000"
 
     def __init__(self, name, version):
+        self.log = logging.getLogger('kernelstub.NVRAM')
+        self.log.debug('Logging set up')
+        self.log.debug('loaded kernelstub.NVRAM')
+
         self.os_label = "%s %s" % (name, version)
         self.update()
 
@@ -61,26 +65,25 @@ class NVRAM():
     def add_entry(self, this_os, this_drive, kernel_opts):
         device = '/dev/%s' % this_drive.name
         esp_num = this_drive.esp_num
-        entry_label = '%s %s' % (this_os.name_pretty, this_os.version)
-        entry_linux = '\\EFI\\%s-%s\\vmlinuz' % (this_os.name, this_drive.root_uuid)
+        entry_label = '%s-%s' % (this_os.name, this_os.version)
+        entry_linux = '\\EFI\\%s-%s\\vmlinuz.efi' % (this_os.name, this_drive.root_uuid)
         root_uuid = this_drive.root_uuid
-        entry_initrd = 'EFI/%s-%s/initrd' % (this_os.name, this_drive.root_uuid)
-        kernel_opts = kernel_opts
+        entry_initrd = 'EFI/%s-%s/initrd.img' % (this_os.name, this_drive.root_uuid)
+        self.log.debug('kernel opts: %s' % kernel_opts)
+
         command = [
             '/usr/bin/sudo',
             'efibootmgr',
+            '-c',
             '-d', device,
             '-p', esp_num,
-            '-c',
-            '-L', '"%s"' % entry_label,
+            '-L', '%s' % entry_label,
             '-l', entry_linux,
             '-u',
             '"initrd=%s' % entry_initrd,
-            '%s"' % kernel_opts,
+            '%s"' % kernel_opts
         ]
-        for option in kernel_opts:
-            command.append(option)
-        command.append('"')
+        self.log.debug('Command is: %s' % command)
         subprocess.run(command)
         self.update()
 

--- a/kernelstub/opsys.py
+++ b/kernelstub/opsys.py
@@ -126,8 +126,8 @@ class OS():
             with open('/etc/os-release') as os_release_file:
                 os_release = os_release_file.readlines()
         except FileNotFoundError:
-            os_release = ['NAME="%s"\n' % self.os_name,
-                          'VERSION="%s"\n' % self.os_version,
+            os_release = ['NAME="%s"\n' % self.name,
+                          'VERSION="%s"\n' % self.version,
                           'ID=linux\n',
                           'ID_LIKE=linux\n',
                           'VERSION_ID="%s"\n' % self.os_version]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ THIS SOFTWARE.
 from distutils.core import setup
 
 setup(name='kernelstub',
-    version='2.0.4',
+    version='2.0.5',
     description='Automatic kernel efistub manager for UEFI',
     url='https://launchpad.net/kernelstub',
     author='Ian Santopietro',


### PR DESCRIPTION
Added some command-line options:
  * Specifying root filesystem
  * Printing current Confguration
  * Turning off setting up loader configuration.

Updated automatic hooks to point to the `/vmlinuz` and `/initrd.img` symlinks.

*Update:* Also add conffiles debian packaging. Fixes isantop/kernelstub#4

@jackpot51 Code review please.

@brs17 Testing steps:

Case 1: 
1. Run `kernelstub -p`
  * The current configuration should be printed out.
2. Run `echo $?`
  * Exit code should be `0`

Case 2:
1. Delete ESP Contents: `sudo rm -r /boot/efi/EFI /boot/efi/loader`
2. Run `kernelstub -vns`
  * Command should run, post output here.
3. Check `echo $?`
  * Code should be `0`
4. Reboot
  * System should reboot and get back into Pop_OS successfully.

Case 3:
1. Delete ESP contents as above.
2. Reboot.
  * System should fail to get back into Pop_OS
3. From live disk, install `kernelstub` package and run:
```
sudo mount /dev/root-filesystem-block-device /mnt
sudo mount /dev/esp-filesystem-block-device /mnt/boot/efi
sudo kernelstub -vmlfr "/mnt" -e "/mnt/boot/efi" -o "quiet loglevel=0"
sudo bootctl --path=/mnt/boot/efi install
```
4. Reboot
  * System should reboot into Pop.
