### PR TITLE
2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ There are other options as well, as detailed below:
 |`-k <path>`, `--kernel-path <path>` | Manually specify the path to the kernel image.    |
 |`-i <path>`, `--initrd-path <path>` | Manually specify the path to the initrd image.    |
 |`-o <options>`,`--options <options>`| Set kernel boot options.*			 |
+|`-a <options> ,`--add-options <options> | Adds new options to the list of kernel boot options.*** |
 |`-g <log>`,`--log-file <log>`	     | Where to save the log file.			 |
 |`-l`, `--loader`                    | Create a `systemd-boot`-compatible loader config.*|
 |`-n`, `--no-loader`		     | Turns off creating the loader configuration.	 |
@@ -83,6 +84,9 @@ There are other options as well, as detailed below:
 *These options save information to the config file.
 
 **This may overwrite another OS's information.
+
+***Does not add options if they are already present in the configuration. Each 
+option is checked individually.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ package locally, use these commands:
 ```
 git clone https://github.com/isantop/kernelstub
 cd kernelstub
-debuild -B
+debuild -b -us -uc
 sudo dpkg -i ../kernelstub*.deb
 ```
 For installation on non-debian systems, or if you prefer to use Python
@@ -147,4 +147,3 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
 OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
 TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
-

--- a/bin/kernelstub
+++ b/bin/kernelstub
@@ -117,7 +117,19 @@ def main(options=None): # Do the thing
         '--options',
         dest = 'k_options',
         metavar = '"OPTIONS"',
-        help = 'The boot options to be passed to the kernel')
+        help = 'The total boot options to be passed to the kernel')
+
+    parser.add_argument(
+        '-a',
+        dest = 'add_options',
+        metavar = '"OPTIONS",',
+        help = '')
+    parser.add_argument(
+        '--add-options',
+        dest = 'add_options',
+        metavar = '"OPTIONS"',
+        help = 'Boot options to add to the configuration ' +
+               '(if they aren\'t already present)')
 
     parser.add_argument(
         '-g',

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kernelstub (2.2.0) bionic; urgency=medium
+
+  * Added an option to add kernel options
+
+ -- Ian Santopietro <ian@system76.com>  Tue, 01 May 2018 10:15:52 -0700
+
 kernelstub (2.1.0) bionic; urgency=medium
 
   * New live-mode feature to prevent automatic runs on live disks

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -187,6 +187,10 @@ class Kernelstub():
         if args.manage_mode:
             configuration['manage_mode'] = True
 
+        if args.add_options:
+            if args.add_options not in configuration['kernel_options']:
+                configuration['kernel_options'] = configuration['kernel_options'] + " %s" % args.add_options
+
 
         log.debug('Checking configuration integrity...')
         try:
@@ -206,6 +210,10 @@ class Kernelstub():
                 'Default. \n\n You can use "-vv" to get the configuration used.')
             log.debug('Configuration we got: \n\n%s' % config.print_config())
             exit(169)
+
+
+
+
 
         if args.force_update:
             force = True

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -187,10 +187,6 @@ class Kernelstub():
         if args.manage_mode:
             configuration['manage_mode'] = True
 
-        if args.add_options:
-            if args.add_options not in configuration['kernel_options']:
-                configuration['kernel_options'] = configuration['kernel_options'] + " %s" % args.add_options
-
 
         log.debug('Checking configuration integrity...')
         try:
@@ -212,8 +208,12 @@ class Kernelstub():
             exit(169)
 
 
-
-
+        if args.add_options:
+            add_opts = args.add_options.split(" ")
+            for opt in add_opts:
+                if opt not in kernel_opts:
+                    kernel_opts = kernel_opts + " %s" % opt
+                    configuration['kernel_options'] = kernel_opts
 
         if args.force_update:
             force = True

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -54,6 +54,25 @@ class CmdLineError(Exception):
 
 class Kernelstub():
 
+    def parse_options(self, options):
+        for index, option in enumerate(options):
+            if '"' in option:
+                matched = False
+                itr = 1
+                while matched == False:
+                    try:
+                        next_option = options[index + itr]
+                        option = '%s %s' % (option, next_option)
+                        options[index + itr] = ""
+                        if '"' in next_option:
+                            matched = True
+                        else:
+                            itr = itr + 1
+                    except IndexError:
+                        matched = True
+            options[index] = option
+        return options
+
     def main(self, args): # Do the thing
 
         log_file_path = '/var/log/kernelstub.log'
@@ -210,6 +229,7 @@ class Kernelstub():
 
         if args.add_options:
             add_opts = args.add_options.split(" ")
+            add_opts = self.parse_options(add_opts)
             for opt in add_opts:
                 if opt not in kernel_opts:
                     kernel_opts = kernel_opts + " %s" % opt

--- a/kernelstub/config.py
+++ b/kernelstub/config.py
@@ -69,6 +69,7 @@ class Config():
         self.log.debug('Configuration found!')
         try:
             user_config = self.config['user']
+            self.log.debug(user_config)
         except KeyError:
             self.config['user'] = self.config['default'].copy()
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class Test(Command):
             run_pyflakes3()
 
 setup(name='kernelstub',
-    version='2.1.0',
+    version='2.2.0',
     description='Automatic kernel efistub manager for UEFI',
     url='https://launchpad.net/kernelstub',
     author='Ian Santopietro',


### PR DESCRIPTION
Adds in a new flag to add kernel options to the list without having to specify existing options. The list of options to be added and split into a list, with each item checked individually. This allows existing options to be skipped if they're already present, while still adding any new options that are present, and prevents adding duplicate options.

@jackpot51 Please do a normal code review

@brs17 Please check functionality as follows:

1. Run `sudo kernelstub -va "test option"`
  * The command should output normally, with the kernel options "test option" added.
2. Run `sudo kernelstub -v`
  * The command should output normally, with the same kernel options as the previous run.
3. Run `sudo kernelstub -va "test another option"`
  * The command should output normally with "another" added to the end of the list of options, and only one instance of "test" and "option".