### PR TITLE
Remove flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Other files here:
 output.log
+.buildconfig
 
 # Debian Packaging artefacts:
 debian/.debhelper/

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ There are other options as well, as detailed below:
 |`-k <path>`, `--kernel-path <path>` | Manually specify the path to the kernel image.    |
 |`-i <path>`, `--initrd-path <path>` | Manually specify the path to the initrd image.    |
 |`-o <options>`,`--options <options>`| Set kernel boot options.*			 |
+|`-a <options> ,`--add-options <options> | Adds new options to the list of kernel boot options.*** |
 |`-g <log>`,`--log-file <log>`	     | Where to save the log file.			 |
 |`-l`, `--loader`                    | Create a `systemd-boot`-compatible loader config.*|
 |`-n`, `--no-loader`		     | Turns off creating the loader configuration.	 |
@@ -83,6 +84,9 @@ There are other options as well, as detailed below:
 *These options save information to the config file.
 
 **This may overwrite another OS's information.
+
+***Does not add options if they are already present in the configuration. Each 
+option is checked individually.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ package locally, use these commands:
 ```
 git clone https://github.com/isantop/kernelstub
 cd kernelstub
-debuild -B
+debuild -b -us -uc
 sudo dpkg -i ../kernelstub*.deb
 ```
 For installation on non-debian systems, or if you prefer to use Python
@@ -147,4 +147,3 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
 OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
 TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
-

--- a/bin/kernelstub
+++ b/bin/kernelstub
@@ -155,7 +155,7 @@ def main(options=None): # Do the thing
         '--delete-options',
         dest = 'remove_options',
         metavar = '"OPTIONS"',
-        help = ('Boot options to remove from the configuration ',
+        help = ('Boot options to remove from the configuration ' +
                 '(if they\'re present already)')
     )
 

--- a/bin/kernelstub
+++ b/bin/kernelstub
@@ -151,7 +151,7 @@ def main(options=None): # Do the thing
         metavar = "OPTIONS",
         help = ''
     )
-    parser-add_argument(
+    parser.add_argument(
         '--delete-options',
         dest = 'remove_options',
         metavar = '"OPTIONS"',
@@ -201,7 +201,7 @@ def main(options=None): # Do the thing
         '--manage-only',
         action = 'store_true',
         dest = 'manage_mode',
-        help = 'Only copy entries, don\'t set up the NVRAM')
+        help = 'Only copy entries, don\'t set up the NVRAM'
     )
 
     parser.add_argument(

--- a/bin/kernelstub
+++ b/bin/kernelstub
@@ -117,7 +117,19 @@ def main(options=None): # Do the thing
         '--options',
         dest = 'k_options',
         metavar = '"OPTIONS"',
-        help = 'The boot options to be passed to the kernel')
+        help = 'The total boot options to be passed to the kernel')
+
+    parser.add_argument(
+        '-a',
+        dest = 'add_options',
+        metavar = '"OPTIONS",',
+        help = '')
+    parser.add_argument(
+        '--add-options',
+        dest = 'add_options',
+        metavar = '"OPTIONS"',
+        help = 'Boot options to add to the configuration ' +
+               '(if they aren\'t already present)')
 
     parser.add_argument(
         '-g',

--- a/bin/kernelstub
+++ b/bin/kernelstub
@@ -52,116 +52,149 @@ def main(options=None): # Do the thing
     install_loader = parser.add_mutually_exclusive_group()
 
     parser.add_argument(
-        '-d',
+        '-c',
         '--dry-run',
         action = 'store_true',
         dest = 'dry_run',
-        help = 'Don\'t perform any actions, just simulate them.')
+        help = 'Don\'t perform any actions, just simulate them.'
+    )
     parser.add_argument(
         '-p',
         '--print-config',
         action = 'store_true',
         dest = 'print_config',
-        help = 'Print the current configuration and exit')
+        help = 'Print the current configuration and exit'
+    )
 
     parser.add_argument(
         '-e',
         dest = 'esp_path',
         metavar = 'ESP,',
-        help = '')
+        help = ''
+    )
     parser.add_argument(
         '--esp-path',
         dest = 'esp_path',
         metavar = 'ESP',
-        help = 'Manually specify the path to the ESP. Default is /boot/efi')
+        help = 'Manually specify the path to the ESP. Default is /boot/efi'
+    )
 
     parser.add_argument(
         '-r',
         dest = 'root_path',
         metavar = 'ROOT',
-        help = '')
+        help = ''
+    )
     parser.add_argument(
         '--root-path',
         dest = 'root_path',
         metavar = 'ROOT',
-        help = 'The path where the root filesystem to use is mounted.')
+        help = 'The path where the root filesystem to use is mounted.'
+    )
 
     parser.add_argument(
         '-k',
         dest = 'kernel_path',
         metavar= 'PATH,',
-        help = '')
+        help = ''
+    )
     parser.add_argument(
         '--kernel-path',
         dest = 'kernel_path',
         metavar= 'PATH',
-        help = 'The path to the kernel image.')
+        help = 'The path to the kernel image.'
+    )
 
     parser.add_argument(
         '-i',
         dest = 'initrd_path',
         metavar = 'PATH,',
-        help = '')
+        help = ''
+    )
     parser.add_argument(
         '--initrd-path',
         dest = 'initrd_path',
         metavar = 'PATH',
-        help = 'The path to the initrd image.')
+        help = 'The path to the initrd image.'
+    )
 
     parser.add_argument(
         '-o',
         dest = 'k_options',
         metavar = '"OPTIONS",',
-        help = '')
+        help = ''
+    )
     parser.add_argument(
         '--options',
         dest = 'k_options',
         metavar = '"OPTIONS"',
-        help = 'The total boot options to be passed to the kernel')
+        help = 'The total boot options to be passed to the kernel'
+    )
 
     parser.add_argument(
         '-a',
         dest = 'add_options',
         metavar = '"OPTIONS",',
-        help = '')
+        help = ''
+    )
     parser.add_argument(
         '--add-options',
         dest = 'add_options',
         metavar = '"OPTIONS"',
-        help = 'Boot options to add to the configuration ' +
+        help = ('Boot options to add to the configuration '
                '(if they aren\'t already present)')
+   )
+
+    parser.add_argument(
+        '-d',
+        dest = 'remove_options',
+        metavar = "OPTIONS",
+        help = ''
+    )
+    parser-add_argument(
+        '--delete-options',
+        dest = 'remove_options',
+        metavar = '"OPTIONS"',
+        help = ('Boot options to remove from the configuration ',
+                '(if they\'re present already)')
+    )
 
     parser.add_argument(
         '-g',
         dest = 'log_file',
         metavar = 'LOG',
-        help = '')
+        help = ''
+    )
     parser.add_argument(
         '--log-file',
         dest = 'log_file',
         metavar = 'LOG',
         help = 'The path to the log file to use. Defaults to ' +
-               '/var/log/kernelstub.log')
+               '/var/log/kernelstub.log'
+    )
 
     install_loader.add_argument(
         '-l',
         '--loader',
         action = 'store_true',
         dest = 'setup_loader',
-        help = 'Creates a systemd-boot compatible loader configuration')
+        help = 'Creates a systemd-boot compatible loader configuration'
+    )
     install_loader.add_argument(
         '-n',
         '--no-loader',
         action = 'store_true',
         dest = 'off_loader',
-        help = 'Turns off creating loader configuration')
+        help = 'Turns off creating loader configuration'
+    )
 
     loader_stub.add_argument(
         '-s',
         '--stub',
         action = 'store_true',
         dest = 'install_stub',
-        help = 'Set up NVRAM entries for the copied kernel')
+        help = 'Set up NVRAM entries for the copied kernel'
+    )
 
     loader_stub.add_argument(
         '-m',
@@ -169,6 +202,7 @@ def main(options=None): # Do the thing
         action = 'store_true',
         dest = 'manage_mode',
         help = 'Only copy entries, don\'t set up the NVRAM')
+    )
 
     parser.add_argument(
         '-f',
@@ -176,14 +210,16 @@ def main(options=None): # Do the thing
         action = 'store_true',
         dest = 'force_update',
         help = 'Forcibly update any loader.conf to set the new entry as the ' +
-               'default')
+               'default'
+    )
 
     parser.add_argument(
         '-v',
         '--verbose',
         action = 'count',
         dest = 'verbosity',
-        help = 'Increase program verbosity and display extra output.')
+        help = 'Increase program verbosity and display extra output.'
+    )
 
     parser.add_argument(
         '--preserve-live-mode',

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+kernelstub (3.0.0) bionic; urgency=medium
+
+  * Breaking API Change in 2.3.0
+    Existing option renamed/removed: --dry-run 
+    Short-form changed
+
+ -- Ian Santopietro <ian@system76.com>  Wed, 13 Jun 2018 10:39:08 -0600
+
 kernelstub (2.3.0) bionic; urgency=medium
 
   * Add flag to remove kernel options from the configuration

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kernelstub (2.2.0) bionic; urgency=medium
+
+  * Added an option to add kernel options
+
+ -- Ian Santopietro <ian@system76.com>  Tue, 01 May 2018 10:15:52 -0700
+
 kernelstub (2.1.0) bionic; urgency=medium
 
   * New live-mode feature to prevent automatic runs on live disks

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kernelstub (2.3.0) bionic; urgency=medium
+
+  * Add flag to remove kernel options from the configuration
+
+ -- Ian Santopietro <ian@system76.com>  Wed, 13 Jun 2018 10:03:03 -0600
+
 kernelstub (2.2.1) bionic; urgency=medium
 
   * Cause kernelstub to exit without an error code if the initrd or kernel

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+kernelstub (2.2.1) bionic; urgency=medium
+
+  * Cause kernelstub to exit without an error code if the initrd or kernel
+    images can't be found.
+
+ -- Ian Santopietro <ian@system76.com>  Wed, 23 May 2018 14:14:34 -0600
+
 kernelstub (2.2.0) bionic; urgency=medium
 
   * Added an option to add kernel options

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -262,7 +262,7 @@ class Kernelstub():
             '    ESP Partition #:.....%s\n'    % drive.esp_num +
             '    NVRAM entry #:.......%s\n'    % nvram.os_entry_index +
             '    Boot Variable #:.....%s\n'    % nvram.order_num +
-            '    Kernel Boot Options:.%s\n'    % kernel_opts +
+            '    Kernel Boot Options:.%s\n'    % " ".join(kernel_opts) +
             '    Kernel Image Path:...%s\n'    % opsys.kernel_path +
             '    Initrd Image Path:...%s\n'    % opsys.initrd_path +
             '    Force-overwrite:.....%s\n'    % str(force))
@@ -271,7 +271,6 @@ class Kernelstub():
 
         if args.print_config:
             all_config = (
-                '   Kernel options:................%s\n' % configuration['kernel_options'] +
                 '   ESP Location:..................%s\n' % configuration['esp_path'] +
                 '   Management Mode:...............%s\n' % configuration['manage_mode'] +
                 '   Install Loader configuration:..%s\n' % configuration['setup_loader'] +
@@ -281,7 +280,7 @@ class Kernelstub():
 
         log.debug('Setting up boot...')
 
-        kopts = 'root=UUID=%s ro %s' % (drive.root_uuid, kernel_opts)
+        kopts = 'root=UUID=%s ro %s' % (drive.root_uuid, " ".join(kernel_opts))
         log.debug('kopts: %s' % kopts)
 
 

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -156,13 +156,13 @@ class Kernelstub():
             log.exception('Can\'t find the kernel image! \n\n'
                          'Please use the --kernel-path option to specify '
                          'the path to the kernel image')
-            exit(166)
+            exit(0)
 
         if not os.path.exists(opsys.initrd_path):
             log.exception('Can\'t find the initrd image! \n\n'
                          'Please use the --initrd-path option to specify '
                          'the path to the initrd image')
-            exit(167)
+            exit(0)
 
         # Check for kernel parameters. Without them, stop and fail
         if args.k_options:

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -229,11 +229,17 @@ class Kernelstub():
 
         if args.add_options:
             add_opts = args.add_options.split(" ")
-            add_opts = self.parse_options(add_opts)
+            add_opts = config.parse_options(add_opts)
             for opt in add_opts:
                 if opt not in kernel_opts:
-                    kernel_opts = kernel_opts + " %s" % opt
+                    kernel_opts.append(opt)
                     configuration['kernel_options'] = kernel_opts
+
+        if args.remove_options:
+            rem_opts = args.remove_options.split(" ")
+            rem_opts = config.parse_options(rem_opts)
+            kernel_opts = list(set(kernel_opts) - set(rem_opts))
+            configuration['kernel_options'] = kernel_opts
 
         if args.force_update:
             force = True

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -54,6 +54,25 @@ class CmdLineError(Exception):
 
 class Kernelstub():
 
+    def parse_options(self, options):
+        for index, option in enumerate(options):
+            if '"' in option:
+                matched = False
+                itr = 1
+                while matched == False:
+                    try:
+                        next_option = options[index + itr]
+                        option = '%s %s' % (option, next_option)
+                        options[index + itr] = ""
+                        if '"' in next_option:
+                            matched = True
+                        else:
+                            itr = itr + 1
+                    except IndexError:
+                        matched = True
+            options[index] = option
+        return options
+
     def main(self, args): # Do the thing
 
         log_file_path = '/var/log/kernelstub.log'
@@ -206,6 +225,15 @@ class Kernelstub():
                 'Default. \n\n You can use "-vv" to get the configuration used.')
             log.debug('Configuration we got: \n\n%s' % config.print_config())
             exit(169)
+
+
+        if args.add_options:
+            add_opts = args.add_options.split(" ")
+            add_opts = self.parse_options(add_opts)
+            for opt in add_opts:
+                if opt not in kernel_opts:
+                    kernel_opts = kernel_opts + " %s" % opt
+                    configuration['kernel_options'] = kernel_opts
 
         if args.force_update:
             force = True

--- a/kernelstub/config.py
+++ b/kernelstub/config.py
@@ -82,6 +82,8 @@ class Config():
                 self.log.warning("Updating old configuration.")
                 self.config = self.update_config(self.config)
                 self.log.info("Configuration updated successfully!")
+            elif self.config['user']['config_rev'] == self.config_default['default']['config_rev']:
+                self.log.debug("Configuration up to date")
             else:
                 raise ConfigError("Configuration cannot be understood!")
         except KeyError:
@@ -100,17 +102,18 @@ class Config():
         return 0
 
     def update_config(self, config):
-        if config['user'] < 2:
+        if config['user']['config_rev'] < 2:
             config['user']['live_mode'] = False
             config['default']['live_mode'] = False
-        if config['user'] < 3:
-            config['user']['kernel_options'] = self.parse_options(config['user']['kernel_options'])
-            config['default']['kernel_options'] = self.parse_options(config['default']['kernel_options'])
+        if config['user']['config_rev'] < 3:
+            config['user']['kernel_options'] = self.parse_options(config['user']['kernel_options'].split())
+            config['default']['kernel_options'] = self.parse_options(config['default']['kernel_options'].split())
         config['user']['config_rev'] = 3
         config['default']['config_rev'] = 3
         return config
 
     def parse_options(self, options):
+        self.log.debug(options)
         for index, option in enumerate(options):
             if '"' in option:
                 matched = False

--- a/kernelstub/config.py
+++ b/kernelstub/config.py
@@ -24,19 +24,22 @@ terms.
 
 import json, os, logging
 
+class ConfigError(Exception):
+    pass
+
 class Config():
 
     config_path = "/etc/kernelstub/configuration"
     config = {}
     config_default = {
         'default': {
-            'kernel_options': 'quiet splash',
+            'kernel_options': ['quiet', 'splash'],
             'esp_path': "/boot/efi",
             'setup_loader': False,
             'manage_mode': False,
             'force_update' : False,
             'live_mode' : False,
-            'config_rev' : 2
+            'config_rev' : 3
         }
     }
 
@@ -75,10 +78,12 @@ class Config():
 
         try:
             self.log.debug('Configuration version: %s' % self.config['user']['config_rev'])
-            if self.config['user']['config_rev'] != self.config_default['default']['config_rev']:
+            if self.config['user']['config_rev'] < self.config_default['default']['config_rev']:
                 self.log.warning("Updating old configuration.")
                 self.config = self.update_config(self.config)
                 self.log.info("Configuration updated successfully!")
+            else:
+                raise ConfigError("Configuration cannot be understood!")
         except KeyError:
             self.log.warning("Attempting upgrade of legacy configuration.")
             self.config = self.update_config(self.config)
@@ -95,11 +100,34 @@ class Config():
         return 0
 
     def update_config(self, config):
-        config['user']['live_mode'] = False
-        config['user']['config_rev'] = 2
-        config['default']['live_mode'] = False
-        config['default']['config_rev'] = 2
+        if config['user'] < 2:
+            config['user']['live_mode'] = False
+            config['default']['live_mode'] = False
+        if config['user'] < 3:
+            config['user']['kernel_options'] = self.parse_options(config['user']['kernel_options'])
+            config['default']['kernel_options'] = self.parse_options(config['default']['kernel_options'])
+        config['user']['config_rev'] = 3
+        config['default']['config_rev'] = 3
         return config
+
+    def parse_options(self, options):
+        for index, option in enumerate(options):
+            if '"' in option:
+                matched = False
+                itr = 1
+                while matched == False:
+                    try:
+                        next_option = options[index + itr]
+                        option = '%s %s' % (option, next_option)
+                        options[index + itr] = ""
+                        if '"' in next_option:
+                            matched = True
+                        else:
+                            itr = itr + 1
+                    except IndexError:
+                        matched = True
+            options[index] = option
+        return options
 
     def print_config(self):
         output_config = json.dumps(self.config, indent=2)

--- a/kernelstub/config.py
+++ b/kernelstub/config.py
@@ -69,6 +69,7 @@ class Config():
         self.log.debug('Configuration found!')
         try:
             user_config = self.config['user']
+            self.log.debug(user_config)
         except KeyError:
             self.config['user'] = self.config['default'].copy()
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class Test(Command):
             run_pyflakes3()
 
 setup(name='kernelstub',
-    version='2.1.0',
+    version='2.2.0',
     description='Automatic kernel efistub manager for UEFI',
     url='https://launchpad.net/kernelstub',
     author='Ian Santopietro',

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class Test(Command):
             run_pyflakes3()
 
 setup(name='kernelstub',
-    version='2.2.0',
+    version='2.2.1',
     description='Automatic kernel efistub manager for UEFI',
     url='https://launchpad.net/kernelstub',
     author='Ian Santopietro',

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class Test(Command):
             run_pyflakes3()
 
 setup(name='kernelstub',
-    version='2.3.0',
+    version='3.0.0',
     description='Automatic kernel efistub manager for UEFI',
     url='https://launchpad.net/kernelstub',
     author='Ian Santopietro',

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class Test(Command):
             run_pyflakes3()
 
 setup(name='kernelstub',
-    version='2.2.1',
+    version='2.3.0',
     description='Automatic kernel efistub manager for UEFI',
     url='https://launchpad.net/kernelstub',
     author='Ian Santopietro',


### PR DESCRIPTION
Adds a flag to remove kernel options from the configuration. The `-d` flag has been re-purposed for this, and the new short-form of the `--dry-run` flag is `-c`.

Testing:

1. Run `sudo kernelstub -va "invalidoption quiet"`
  * Ensure that the `invalidoption` is added to the list of options
  * Ensure that the `quiet` is not added again
2. Run `sudo kernelstub -vd "invalidoption anotherinvalidoption"`
  * Ensure that the `invalid option is removed from the list of options
  * Ensure that the `anotherinvalidoption` is neither added nor removed, and that there are no error messages from it's inclusion