### PR TITLE
Fix for #20

### DIFF
--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -166,7 +166,7 @@ class Kernelstub():
 
         # Check for kernel parameters. Without them, stop and fail
         if args.k_options:
-            configuration['kernel_options'] = args.k_options
+            configuration['kernel_options'] = self.parse_options(args.k_options.split())
         else:
             try:
                 configuration['kernel_options']


### PR DESCRIPTION
Seems that kernel options provided to the command are not being split into an array, and thus any attempt to iterate on it will iterate by characters instead of words.

Closes #20