### PR TITLE
Fix bug in path to UUID code with multi-device btrfs

### DIFF
--- a/kernelstub/drive.py
+++ b/kernelstub/drive.py
@@ -22,7 +22,7 @@ Please see the provided LICENSE.txt file for additional distribution/copyright
 terms.
 """
 
-import os, logging
+import os, logging, subprocess
 
 class NoBlockDevError(Exception):
     pass
@@ -56,7 +56,7 @@ class Drive():
             self.esp_fs = self.get_part_dev(self.esp_path)
             self.drive_name = self.get_drive_dev(self.esp_fs)
             self.esp_num = self.esp_fs[-1]
-            self.root_uuid = self.get_uuid(self.root_fs[5:])
+            self.root_uuid = self.get_uuid(self.root_path)
         except NoBlockDevError as e:
             self.log.exception('Could not find a block device for the a ' +
                                'partition. This is a critical error and we ' +
@@ -102,15 +102,13 @@ class Drive():
         self.log.debug('ESP is a partition on /dev/%s' % disk_name)
         return disk_name
 
-    def get_uuid(self, fs):
-        all_uuids = os.listdir('/dev/disk/by-uuid')
-        self.log.debug('Looking for UUID for %s' % fs)
-        self.log.debug('List of UUIDs:\n%s' % all_uuids)
-
-        for uuid in all_uuids:
-            uuid_path = os.path.join('/dev/disk/by-uuid', uuid)
-            if fs in os.path.realpath(uuid_path):
-                return uuid
-
-        raise UUIDNotFoundError
-    
+    def get_uuid(self, path):
+        self.log.debug('Looking for UUID for path %s' % path)
+        try:
+            args = ['findmnt', '-n', '-o', 'uuid', '--mountpoint', path]
+            result = subprocess.run(args, stdout=subprocess.PIPE)
+            uuid = result.stdout.decode('ASCII')
+            uuid = uuid.strip()
+            return uuid
+        except:
+            raise UUIDNotFoundError


### PR DESCRIPTION
This also makes the UUID matching code more robust
at the expense of using the external tool `findmnt'

This bug is caused by the assumtion that there is a
1-1 correspondence between device files and UUIDs
(which is almost always true). Unfortunately BTRFS
multi-device filesystems may have multiple devices
associated with a single UUID. The old link reading
code does not handle this case and fails to work.

Ultimately it's probably better to use a upstream
maintained tool for computing path -> UUID as it
is subtle and not a core problem this tool is trying
to solve. Also, `findmnt' is already provided by the
`util-linux' package so another package dependency
is not added.