### PR TITLE
Use latest kernel option if no kernel parameter is provided

### DIFF
--- a/data/initramfs/zz-kernelstub
+++ b/data/initramfs/zz-kernelstub
@@ -5,6 +5,4 @@ INITRD="$2"
 
 kernelstub \
   --verbose \
-  --initrd-path "/initrd.img" \
-  --kernel-path "/vmlinuz" \
   --preserve-live-mode

--- a/data/kernel/zz-kernelstub
+++ b/data/kernel/zz-kernelstub
@@ -5,6 +5,4 @@ KERNEL="$2"
 
 kernelstub \
   --verbose \
-  --initrd-path "/initrd.img" \
-  --kernel-path "/vmlinuz" \
   --preserve-live-mode

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kernelstub (3.1.2) eoan; urgency=medium
+
+  * Use latest kernel option if no kernel parameter is provided
+
+ -- Jeremy Soller <jeremy@system76.com>  Tue, 08 Oct 2019 15:10:55 -0600
+
 kernelstub (3.1.1) eoan; urgency=medium
 
   * Check for vmlinuz and initrd.img links in /boot

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kernelstub (3.1.1) eoan; urgency=medium
+
+  * Check for vmlinuz and initrd.img links in /boot
+
+ -- Jeremy Soller <jeremy@system76.com>  Wed, 07 Aug 2019 13:00:38 -0600
+
 kernelstub (3.1.0) bionic; urgency=medium
 
   * Add logging to systemd journald

--- a/debian/control
+++ b/debian/control
@@ -5,13 +5,9 @@ Priority: optional
 Build-Depends: python3-all, pyflakes3, debhelper (>= 7.4.3)
 Standards-Version: 3.9.1
 
-
-
-
-
 Package: kernelstub
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, efibootmgr, util-linux
+Depends: ${misc:Depends}, ${python3:Depends}, efibootmgr, python3-debian, util-linux
 Recommends: python3-systemd
 Description: Automatic kernel efistub manager for UEFI
 

--- a/debian/kernelstub.postinst
+++ b/debian/kernelstub.postinst
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+kernelstub \
+  --verbose \
+  --preserve-live-mode

--- a/debian/pop-boot.postinst
+++ b/debian/pop-boot.postinst
@@ -2,8 +2,6 @@
 
 kernelstub \
 	--esp-path "/boot/efi" \
-	--kernel-path "/vmlinuz" \
-	--initrd-path "/initrd.img" \
 	--options "quiet loglevel=0" \
 	--loader \
 	--manage-only \

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -148,6 +148,8 @@ class Kernelstub():
         if args.root_path:
             root_path = args.root_path
 
+        boot_path = os.path.join(root_path, 'boot')
+
         opsys = Opsys.OS()
 
         if args.kernel_path:
@@ -156,7 +158,7 @@ class Kernelstub():
                 '               %s' % args.kernel_path)
             opsys.kernel_path = args.kernel_path
         else:
-            opsys.kernel_path = os.path.join(root_path, 'boot', opsys.kernel_name)
+            opsys.kernel_path = os.path.join(boot_path, opsys.kernel_name)
             if not os.path.exists(opsys.kernel_path):
                 opsys.kernel_path = os.path.join(root_path, opsys.kernel_name)
 
@@ -166,7 +168,7 @@ class Kernelstub():
                 '               %s' % args.initrd_path)
             opsys.initrd_path = args.initrd_path
         else:
-            opsys.initrd_path = os.path.join(root_path, 'boot', opsys.initrd_name)
+            opsys.initrd_path = os.path.join(boot_path, opsys.initrd_name)
             if not os.path.exists(opsys.initrd_path):
                 opsys.initrd_path = os.path.join(root_path, opsys.initrd_name)
 

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -56,6 +56,7 @@ from . import nvram as Nvram
 from . import opsys as Opsys
 from . import installer as Installer
 from . import config as Config
+from . import kernel_option as KernelOption
 
 class CmdLineError(Exception):
     pass
@@ -149,6 +150,7 @@ class Kernelstub():
             root_path = args.root_path
 
         boot_path = os.path.join(root_path, 'boot')
+        latest_option = KernelOption.latest_option(boot_path)
 
         opsys = Opsys.OS()
 
@@ -157,6 +159,8 @@ class Kernelstub():
                 'Manually specified kernel path:\n ' +
                 '               %s' % args.kernel_path)
             opsys.kernel_path = args.kernel_path
+        elif latest_option:
+            opsys.kernel_path = latest_option['kernel']
         else:
             opsys.kernel_path = os.path.join(boot_path, opsys.kernel_name)
             if not os.path.exists(opsys.kernel_path):
@@ -167,6 +171,8 @@ class Kernelstub():
                 'Manually specified initrd path:\n ' +
                 '               %s' % args.initrd_path)
             opsys.initrd_path = args.initrd_path
+        elif latest_option:
+            opsys.initrd_path = latest_option['initrd']
         else:
             opsys.initrd_path = os.path.join(boot_path, opsys.initrd_name)
             if not os.path.exists(opsys.initrd_path):

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -156,7 +156,9 @@ class Kernelstub():
                 '               %s' % args.kernel_path)
             opsys.kernel_path = args.kernel_path
         else:
-            opsys.kernel_path = os.path.join(root_path, opsys.kernel_name)
+            opsys.kernel_path = os.path.join(root_path, 'boot', opsys.kernel_name)
+            if not os.path.exists(opsys.kernel_path):
+                opsys.kernel_path = os.path.join(root_path, opsys.kernel_name)
 
         if args.initrd_path:
             log.debug(
@@ -164,16 +166,18 @@ class Kernelstub():
                 '               %s' % args.initrd_path)
             opsys.initrd_path = args.initrd_path
         else:
-            opsys.initrd_path = os.path.join(root_path, opsys.initrd_name)
+            opsys.initrd_path = os.path.join(root_path, 'boot', opsys.initrd_name)
+            if not os.path.exists(opsys.initrd_path):
+                opsys.initrd_path = os.path.join(root_path, opsys.initrd_name)
 
         if not os.path.exists(opsys.kernel_path):
-            log.exception('Can\'t find the kernel image! \n\n'
+            log.exception('Can\'t find the kernel image \'' + opsys.kernel_path + '\'! \n\n'
                          'Please use the --kernel-path option to specify '
                          'the path to the kernel image')
             exit(0)
 
         if not os.path.exists(opsys.initrd_path):
-            log.exception('Can\'t find the initrd image! \n\n'
+            log.exception('Can\'t find the initrd image \'' + opsys.initrd_path + '\'! \n\n'
                          'Please use the --initrd-path option to specify '
                          'the path to the initrd image')
             exit(0)
@@ -328,4 +332,3 @@ class Kernelstub():
         log.debug('Setup complete!\n\n')
 
         return 0
-

--- a/kernelstub/kernel_option.py
+++ b/kernelstub/kernel_option.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+
+from debian.changelog import Version
+import os
+import os.path
+
+def options(path):
+    items={}
+    for name in os.listdir(path):
+        key = None
+        if name.startswith("vmlinuz-"):
+            key = "kernel"
+        elif name.startswith("initrd.img-"):
+            key = "initrd"
+
+        if key is None:
+            continue
+
+        parts = name.split("-", 1)
+        version = parts[1]
+
+        if not version in items:
+            items[version] = {}
+
+        items[version][key] = os.path.join(path, name)
+
+    return items
+
+def latest_option(path):
+    latest_version = None
+    latest_option = None
+    for version, option in options(path).items():
+        # If option is not complete, skip
+        if 'kernel' not in option or 'initrd' not in option:
+            continue
+
+        # If this option is newer, store this option and continue
+        if latest_version is None or Version(version) > Version(latest_version):
+            latest_version = version
+            latest_option = option
+
+    return latest_option
+
+if __name__ == "__main__":
+    print(latest_option("/boot"))

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class Test(Command):
             run_pyflakes3()
 
 setup(name='kernelstub',
-    version='3.1.0',
+    version='3.1.2',
     description='Automatic kernel efistub manager for UEFI',
     url='https://launchpad.net/kernelstub',
     author='Ian Santopietro',


### PR DESCRIPTION
The purpose of this change is to fix an issue whereby the running kernel is stuck on an old version due to the /vmlinuz and /initrd.img not pointing to the latest kernel. That can cause serious issues since the running kernel can never be removed with apt, and users could be stuck on a vulnerable or unsupported kernel version.

This change will locate the latest kernel option, and use that as the default in the case that no --kernel-path or --initrd-path is passed to kernelstub. It will also cause kernelstub to run any time it is upgraded with apt. This should safely transition users on old kernels to the correct version.

This also merges changes to support eoan, rendering master_eoan obsolete after this is merged.