### PR TITLE
Boot menu flag

### DIFF
--- a/bin/kernelstub
+++ b/bin/kernelstub
@@ -52,6 +52,21 @@ def main(options=None): # Do the thing
     install_loader = parser.add_mutually_exclusive_group()
 
     parser.add_argument(
+        '-b',
+        '--boot-menu',
+        action='store_true',
+        help='Show the systemd-boot menu on the next boot'
+    )
+    # We need a way to hide the boot menu again after the system boots to the 
+    # menu, but this is of limited use to regular users. Hence we hide it from
+    # the help output.
+    parser.add_argument(
+        '--re-hide-boot-menu',
+        action='store_true',
+        help=argparse.SUPPRESS
+    )
+
+    parser.add_argument(
         '-c',
         '--dry-run',
         action = 'store_true',

--- a/data/systemd/kernelstub-hide-menu.service
+++ b/data/systemd/kernelstub-hide-menu.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Kernelstub: Restore User Configuration
+
+[Service]
+ExecStart=/usr/lib/kernelstub/kernelstub-hide-menu.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/data/systemd/kernelstub-hide-menu.sh
+++ b/data/systemd/kernelstub-hide-menu.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+#  kernelstub
+#  The automatic manager for using the Linux Kernel EFI Stub to boot
+
+#  Copyright 2017-2018 Ian Santopietro <isantop@gmail.com>
+
+# Permission to use, copy, modify, and/or distribute this software for any purpose
+# with or without fee is hereby granted, provided that the above copyright notice
+# and this permission notice appear in all copies.
+
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+# INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+# OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+# TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+# THIS SOFTWARE.
+
+# Please see the provided LICENSE.txt file for additional distribution/copyright
+# terms.
+
+# This file will restore previous boot configuration after using the 
+# `--boot-menu` option to show the boot menu automatically.
+
+/usr/bin/kernelstub --re-hide-boot-menu

--- a/debian/kernelstub.postinst
+++ b/debian/kernelstub.postinst
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl enable kernelstub-hide-menu

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -270,32 +270,6 @@ class Kernelstub():
         nvram = Nvram.NVRAM(opsys.name, opsys.version)
         installer = Installer.Installer(nvram, opsys, drive)
 
-        # Log some helpful information, to file and optionally console
-        info = (
-            '    OS:..................%s %s\n' %(opsys.name_pretty,opsys.version) +
-            '    Root partition:......%s\n'    % drive.root_fs +
-            '    Root FS UUID:........%s\n'    % drive.root_uuid +
-            '    ESP Path:............%s\n'    % esp_path +
-            '    ESP Partition:.......%s\n'    % drive.esp_fs +
-            '    ESP Partition #:.....%s\n'    % drive.esp_num +
-            '    NVRAM entry #:.......%s\n'    % nvram.os_entry_index +
-            '    Boot Variable #:.....%s\n'    % nvram.order_num +
-            '    Kernel Boot Options:.%s\n'    % " ".join(kernel_opts) +
-            '    Kernel Image Path:...%s\n'    % opsys.kernel_path +
-            '    Initrd Image Path:...%s\n'    % opsys.initrd_path +
-            '    Force-overwrite:.....%s\n'    % str(force))
-
-        log.info('System information: \n\n%s' % info)
-
-        if args.print_config:
-            all_config = (
-                '   ESP Location:..................%s\n' % configuration['esp_path'] +
-                '   Management Mode:...............%s\n' % configuration['manage_mode'] +
-                '   Install Loader configuration:..%s\n' % configuration['setup_loader'] +
-                '   Configuration version:.........%s\n' % configuration['config_rev'])
-            log.info('Configuration details: \n\n%s' % all_config)
-            exit(0)
-        
         # This method preserves any configuration changes that the user may have
         # made when they choose to show the boot menu. This avoids the need to 
         # parse the loader.conf file
@@ -321,6 +295,32 @@ class Kernelstub():
                 os.rename(loader_backup, loader_path)
             except FileNotFoundError:
                 log.info('No previous user configuration found')
+            exit(0)
+
+        # Log some helpful information, to file and optionally console
+        info = (
+            '    OS:..................%s %s\n' %(opsys.name_pretty,opsys.version) +
+            '    Root partition:......%s\n'    % drive.root_fs +
+            '    Root FS UUID:........%s\n'    % drive.root_uuid +
+            '    ESP Path:............%s\n'    % esp_path +
+            '    ESP Partition:.......%s\n'    % drive.esp_fs +
+            '    ESP Partition #:.....%s\n'    % drive.esp_num +
+            '    NVRAM entry #:.......%s\n'    % nvram.os_entry_index +
+            '    Boot Variable #:.....%s\n'    % nvram.order_num +
+            '    Kernel Boot Options:.%s\n'    % " ".join(kernel_opts) +
+            '    Kernel Image Path:...%s\n'    % opsys.kernel_path +
+            '    Initrd Image Path:...%s\n'    % opsys.initrd_path +
+            '    Force-overwrite:.....%s\n'    % str(force))
+
+        log.info('System information: \n\n%s' % info)
+
+        if args.print_config:
+            all_config = (
+                '   ESP Location:..................%s\n' % configuration['esp_path'] +
+                '   Management Mode:...............%s\n' % configuration['manage_mode'] +
+                '   Install Loader configuration:..%s\n' % configuration['setup_loader'] +
+                '   Configuration version:.........%s\n' % configuration['config_rev'])
+            log.info('Configuration details: \n\n%s' % all_config)
             exit(0)
 
         log.debug('Setting up boot...')

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -299,7 +299,8 @@ class Kernelstub():
         # This method preserves any configuration changes that the user may have
         # made when they choose to show the boot menu. This avoids the need to 
         # parse the loader.conf file
-        if args.show_menu:
+        if args.boot_menu:
+            log.info('Setting to show the boot menu on the next boot.')
             loader_path = os.path.join(installer.loader_dir, 'loader.conf')
             loader_backup = os.path.join(
                 installer.loader_dir,
@@ -310,12 +311,16 @@ class Kernelstub():
             exit(0)
         
         if args.re_hide_boot_menu:
+            log.info('Restoring previous user configuration')
             loader_path = os.path.join(installer.loader_dir, 'loader.conf')
             loader_backup = os.path.join(
                 installer.loader_dir,
                 'old-loader.conf.backup'
             )
-            os.rename(loader_backup, loader_path)
+            try:
+                os.rename(loader_backup, loader_path)
+            except FileNotFoundError:
+                log.info('No previous user configuration found')
             exit(0)
 
         log.debug('Setting up boot...')

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -295,6 +295,28 @@ class Kernelstub():
                 '   Configuration version:.........%s\n' % configuration['config_rev'])
             log.info('Configuration details: \n\n%s' % all_config)
             exit(0)
+        
+        # This method preserves any configuration changes that the user may have
+        # made when they choose to show the boot menu. This avoids the need to 
+        # parse the loader.conf file
+        if args.show_menu:
+            loader_path = os.path.join(installer.loader_dir, 'loader.conf')
+            loader_backup = os.path.join(
+                installer.loader_dir,
+                'old-loader.conf.backup'
+            )
+            os.rename(loader_path, loader_backup)
+            installer.overwrite_config(show_menu=True)
+            exit(0)
+        
+        if args.re_hide_boot_menu:
+            loader_path = os.path.join(installer.loader_dir, 'loader.conf')
+            loader_backup = os.path.join(
+                installer.loader_dir,
+                'old-loader.conf.backup'
+            )
+            os.rename(loader_backup, loader_path)
+            exit(0)
 
         log.debug('Setting up boot...')
 

--- a/kernelstub/installer.py
+++ b/kernelstub/installer.py
@@ -166,12 +166,7 @@ class Installer():
                     overwrite = True
 
             if overwrite:
-                self.ensure_dir(self.loader_dir)
-                with open(
-                    '%s/loader.conf' % self.loader_dir, mode='w') as loader:
-
-                    default_line = 'default %s-current\n' % self.opsys.name
-                    loader.write(default_line)
+                self.overwrite_config()
 
             self.ensure_dir(self.entry_dir)
             self.make_loader_entry(
@@ -182,7 +177,13 @@ class Installer():
                 os.path.join(self.entry_dir, '%s-current' % self.opsys.name))
 
 
+    def overwrite_config(self):
+        self.ensure_dir(self.loader_dir)
+        with open(
+            '%s/loader.conf' % self.loader_dir, mode='w') as loader:
 
+            default_line = 'default %s-current\n' % self.opsys.name
+            loader.write(default_line)
 
 
     def setup_stub(self, kernel_opts, simulate=False):

--- a/kernelstub/installer.py
+++ b/kernelstub/installer.py
@@ -177,13 +177,17 @@ class Installer():
                 os.path.join(self.entry_dir, '%s-current' % self.opsys.name))
 
 
-    def overwrite_config(self):
+    def overwrite_config(self, show_menu=False):
         self.ensure_dir(self.loader_dir)
         with open(
             '%s/loader.conf' % self.loader_dir, mode='w') as loader:
 
             default_line = 'default %s-current\n' % self.opsys.name
             loader.write(default_line)
+            
+            if show_menu:
+                show_line = 'timeout 10\n'
+                loader.write(show_line)
 
 
     def setup_stub(self, kernel_opts, simulate=False):

--- a/setup.py
+++ b/setup.py
@@ -85,5 +85,7 @@ setup(name='kernelstub',
     data_files=[
         ('/etc/kernel/postinst.d', ['data/kernel/zz-kernelstub']),
         ('/etc/initramfs/post-update.d', ['data/initramfs/zz-kernelstub']),
-        ('/etc/default', ['data/config/kernelstub.SAMPLE'])]
+        ('/etc/default', ['data/config/kernelstub.SAMPLE']),
+        ('/usr/lib/kernelstub', ['data/systemd/kernelstub-hide-menu.sh']),
+        ('/lib/systemd/system', ['data/systemd/kernelstub-hide-menu.service'])]
     )


### PR DESCRIPTION
Adds a `-b` flag that will cause the next boot to display the systemd-boot menu for 10 seconds on the next boot. It also adds a systemd service to reset the configuration to the previously-specified setup if this was setup.

For testing this we should:

- [ ] Use `sudo kernelstub -vb` to set the flag, reboot, and confirm that it displays the systemd-boot menu on the next boot. 
- [ ] On subsequent boots, it should not display the menu. 
- [ ] Check that `sudo kernelstub --re-hide-boot-menu || echo "ERROR"` does not return an error (as this runs automatically every boot). 
- [ ] Test that if a different timeout (e.g. 3 seconds) is set in the `loader.conf`, the timeout is 10 seconds after running this command, and then returns to 3 seconds for subsequent boots.