### PR TITLE
Ensure conffiles are set explicitly

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kernelstub
 Maintainer: Ian Santopietro <isantop@gmail.com>
 Section: python
 Priority: optional
-Build-Depends: python3-all, pyflakes3, debhelper (>= 7.4.3)
+Build-Depends: python3-all, pyflakes3, debhelper (>= 7.4.3), dh-python
 Standards-Version: 3.9.1
 
 Package: kernelstub

--- a/debian/rules
+++ b/debian/rules
@@ -6,12 +6,9 @@
 %:
 	dh $@ --with python3 --buildsystem=python_distutils
 
-
 override_dh_auto_clean:
 	python3 setup.py clean -a
 	find . -name \*.pyc -exec rm {} \;
-
-
 
 override_dh_auto_build:
 	python3 setup.py build --force
@@ -21,16 +18,12 @@ override_dh_auto_test:
 	    $$python -Werror setup.py test; \
 	done
 
-
-
 override_dh_auto_install:
-	python3 setup.py install --force --root=debian/kernelstub --no-compile -O0 --install-layout=deb  
+	python3 setup.py install --force --root=debian/kernelstub --no-compile -O0 --install-layout=deb
 
-
+override_dh_installdeb:
+	dh_installdeb
+	cp debian/conffiles debian/kernelstub/DEBIAN/conffiles
 
 override_dh_python2:
 	dh_python2 --no-guessing-versions
-
-
-
-


### PR DESCRIPTION
This will copy the conffiles in the debian directory to the final package, similar to how default-settings does it. Whitespace is cleaned up as well