### PR TITLE
uuid to "UUID"

### DIFF
--- a/kernelstub/drive.py
+++ b/kernelstub/drive.py
@@ -105,7 +105,7 @@ class Drive():
     def get_uuid(self, path):
         self.log.debug('Looking for UUID for path %s' % path)
         try:
-            args = ['findmnt', '-n', '-o', 'uuid', '--mountpoint', path]
+            args = ['findmnt', '-n', '-o', 'UUID', '--mountpoint', path]
             result = subprocess.run(args, stdout=subprocess.PIPE)
             uuid = result.stdout.decode('ASCII')
             uuid = uuid.strip()


### PR DESCRIPTION
In turkish systems "findmnt -o uuid" gives no output. LANG=C findmnt -o uuid or findmnt -o UUID should be used. I think its caused by "I,İ" letters.
Otherwise systemd-boot doesnt boot because root=UUID= always blank after update-initramfs.

Anyways its really critical bug for Turkish lang users