### PR TITLE
docs(readme): update with list of build depends

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,23 @@ new kernel versions are installed).
 
 Installation can be handled through the supplied Debian packaging as well as the
 python packaging. If kernelstub is packaged in your distro's repositories, you
-can install kernelstub through the `kernelstub` package. To build a debian
-package locally, use these commands:
+can install kernelstub through the `kernelstub` package. 
+
+To build a debian package locally, first install the build dependencies. On 
+Pop_OS, you can install the build dependencies using this command:
+```
+sudo apt build-dep kernelstub
+```
+
+Otherwise, you will need to install the following packages:
+```
+python3-all
+pyflakes3
+debhelper (>= 7.4.3)
+dh-python
+```
+
+Then use these commands to build the package:
 ```
 git clone https://github.com/isantop/kernelstub
 cd kernelstub

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ python packaging. If kernelstub is packaged in your distro's repositories, you
 can install kernelstub through the `kernelstub` package. 
 
 To build a debian package locally, first install the build dependencies. On 
-Pop_OS, you can install the build dependencies using this command:
+Pop!\_OS, you can install the build dependencies using this command:
 ```
 sudo apt build-dep kernelstub
 ```
@@ -33,7 +33,7 @@ Then use these commands to build the package:
 ```
 git clone https://github.com/isantop/kernelstub
 cd kernelstub
-debuild -b -us -uc
+dpkg-buildpackage -b -us -uc
 sudo dpkg -i ../kernelstub*.deb
 ```
 For installation on non-debian systems, or if you prefer to use Python


### PR DESCRIPTION
Adds a list of build dependencies which need to be installed to build the package locally. Additionally adds instructions for adding the build-deps on Pop_OS (where the kernelstub source package is available).

Fixes #46