### PR TITLE
fix(args): add missing quotation marks around -d OPTIONS

### DIFF
--- a/bin/kernelstub
+++ b/bin/kernelstub
@@ -148,7 +148,7 @@ def main(options=None): # Do the thing
     parser.add_argument(
         '-d',
         dest = 'remove_options',
-        metavar = "OPTIONS",
+        metavar = '"OPTIONS"',
         help = ''
     )
     parser.add_argument(


### PR DESCRIPTION
Presently there are missing quotation marks around the term `OPTIONS` in the help output for the `-d` flag (only the short version). This adds the missing quotation marks to make sure this command matches the other option-manipulation flags.

We print quotations around these to help encourage users to wrap their options lists in quotes. It works fine without for single-option lists, but for more than one we need to wrap them with quotes because the shell will treat each item in the space-separated list as a different shopt.