### PR TITLE
fix(pop-boot): improve pop-boot postinst

### DIFF
--- a/debian/pop-boot.postinst
+++ b/debian/pop-boot.postinst
@@ -1,10 +1,21 @@
 #!/bin/bash
 
-kernelstub \
-	--esp-path "/boot/efi" \
-	--options "quiet loglevel=0" \
-	--loader \
-	--manage-only \
-	--verbose
+DISTRO_EFI_PATH=/boot/efi
+DISTRO_LOADER_CONF_PATH=$DISTRO_EFI_PATH/loader/loader.conf
+DISTRO_DFAULT_KERNEL_OPTIONS=quiet splash loglevel=0
 
-bootctl install --path=/boot/efi
+if [ ! -f $DISTRO_LOADER_CONF_PATH ]; then
+	kernelstub \
+		--esp-path "$DISTRO_EFI_PATH" \
+		--options "$DISTRO_DEFAULT_KERNEL_OPTIONS" \
+		--loader \
+		--manage-only \
+		--verbose
+
+	bootctl install --path=$DISTRO_EFI_PATH
+
+else
+	echo "Loader configuration found in $DISTRO_LOADER_CONF_PATH, not \
+performing initial config"
+
+fi


### PR DESCRIPTION
This ensures that pop-boot's postinst doesn't run if boot configuration is
already present on the system. Otherwise, it may overwrite the system boot
options with new ones, which isn't good. It also makes these fields much
easier to modify and maintain, and prints a helpful message if it skipped
the postinst because the configuration was already found (along with that
config location).