### PR TITLE
Fix build in Jammy and some immutable environments

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kernelstub
 Maintainer: Ian Santopietro <isantop@gmail.com>
 Section: python
 Priority: optional
-Build-Depends: python3-all, pyflakes3, debhelper (>= 7.4.3), dh-python
+Build-Depends: python3-all, pyflakes3, debhelper (>= 7.4.3), dh-python, python3-setuptools
 Standards-Version: 3.9.1
 
 Package: kernelstub

--- a/kernelstub/kernel_option.py
+++ b/kernelstub/kernel_option.py
@@ -46,7 +46,8 @@ def latest_option(path):
     opts = options(path)
     latest_option, latest_version = get_newest_option(opts)
     
-    opts.pop(latest_version)
+    if latest_version is not None:
+        opts.pop(latest_version)
     previous_option = None
     if len(opts) > 0:
         previous_option, latest_version = get_newest_option(opts)

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ Portions of test-related code authored by Jason DeRose <jason@system76.com>
 """
 
 
-from distutils.core import setup
-from distutils.cmd import Command
+from setuptools import setup
+from setuptools import Command
 import os, subprocess, sys
 
 TREE = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
[f383caf](https://github.com/pop-os/kernelstub/pull/64/commits/f383caf3ca459ba790523c393ae734df5b01c73f) - Fixes build in Jammy

[c567d1b](https://github.com/pop-os/kernelstub/pull/64/commits/c567d1b2f866484c3e21327783843fca7a83dc27) - Kernelstub will crash when used in building some immutable images because the latest_version will be none.